### PR TITLE
Fix double stock, Add Description a ApproForm

### DIFF
--- a/salon/forms.py
+++ b/salon/forms.py
@@ -69,4 +69,4 @@ class ApproProduitForm(forms.ModelForm):
 
     class Meta:
         model = Approvisionnement
-        fields = ["produit", "quantite", "pau"]
+        fields = ["produit", "quantite", "pau", "description"]

--- a/salon/templates/salon/produits.html
+++ b/salon/templates/salon/produits.html
@@ -115,6 +115,12 @@
                                             {{ appro_form.pau | as_crispy_field }}
                                         </div>
                                     </div>
+                                    <div class="col-xl-3 col-sm-4 col-12">
+                                        <div class="mb-3">
+                                            <label class="form-label" for="id_description">Description</label>
+                                            {{ appro_form.description | as_crispy_field }}
+                                        </div>
+                                    </div>
 
                                     <!-- Zone d'affichage des messages -->
                                     <div id="response-message-appro" class="alert bg-success text-white alert-dismissible fade" role="alert">
@@ -185,6 +191,7 @@
                                 <th>Prix Achat U</th>
                                 <th>Nouveau Stock</th>
                                 <th>Date Appro</th>
+                                <th>Description</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -248,6 +255,7 @@
                 { data: 'pau'},
                 { data: 'stock'},
                 { data: 'date_appro'},
+                { data: 'description'},
             ]
         })
 
@@ -283,8 +291,10 @@
 
                     $('#produit-form')[0].reset();
 
-                    // Actualiser la Table liste produit via ajax
-                    //tableProduits.ajax.reload();
+                    // Actualiser la Table liste Historiques Appro via ajax
+                    tableProduits.ajax.reload();
+                    tableAppro.ajax.reload()
+
                 },
                 error: function(xhr){
                     const errorResponse = xhr.responseJSON ? xhr.responseJSON.msg : 'Erreur serveur.';
@@ -324,7 +334,8 @@
 
                     $('#form-appro')[0].reset();
 
-                    // Actualiser la Table liste produit via ajax pour afficher le nouveau Stock et le PAU
+                    // Actualiser la Table liste produit et Historique Appro via ajax pour afficher le nouveau Stock et le PAU
+                    tableAppro.ajax.reload();
                     tableProduits.ajax.reload();
                 },
                 error: function(xhr){

--- a/salon/views.py
+++ b/salon/views.py
@@ -209,7 +209,7 @@ def add_produit(request):
                 return JsonResponse({"error": True, "msg": "Le prix de vente doit être superieur à 0"}, status=400)
 
             new_product = Produit.objects.create(
-                designation=designation, prix_achat=prix_achat, prix_vente=prix_vente, stock=stock_init, image=image
+                designation=designation, prix_achat=prix_achat, prix_vente=prix_vente, image=image
             )
             new_product.approvisionner_produit(quantite=stock_init, prix_achat_u=prix_achat, description="Stock initial")
 
@@ -252,6 +252,7 @@ def get_produits(request):
                 "quantite": appro.quantite,
                 "stock": appro.produit.stock,
                 "date_appro": appro.created_at.strftime("%d/%m/%Y"),
+                "description": appro.description,
             })
 
         data = {"list_produits": list_produits, "list_appro": list_appro}
@@ -269,10 +270,11 @@ def approvisionner_produit(request):
             produit = appro_form_submitted.cleaned_data['produit']
             quantite = appro_form_submitted.cleaned_data['quantite']
             pau = appro_form_submitted.cleaned_data['pau']
+            description = appro_form_submitted.cleaned_data['description']
 
             produit_a_approvisionner = Produit.objects.get(id=produit.id)
             # Approvisionnement du Produit
-            produit_a_approvisionner.approvisionner_produit(int(quantite), pau)
+            produit_a_approvisionner.approvisionner_produit(int(quantite), pau, description=description)
 
             return JsonResponse({"success": True, "msg": "Approvisionnement effectué !"}, status=200)
 


### PR DESCRIPTION
- Enlever le paramètre stock lors de la création du Produit afin d'éviter de doubler le stock initial
- Ajouter le champ Description au formulaire d'approvisionnement de Produit
- Actualiser la liste des Produits et Historiques Appro après ajout