### PR TITLE
Refonte des models de l'app Client et Salon

### DIFF
--- a/client/models.py
+++ b/client/models.py
@@ -1,7 +1,6 @@
 from django.db import models
 
 from employe.models import MyBaseModel
-from salon.models import Service, PrixService
 
 
 class Client(MyBaseModel):
@@ -39,14 +38,6 @@ class Piscine(MyBaseModel):
     prix_unitaire = models.BigIntegerField()
     reduction = models.BigIntegerField(null=True)
     note = models.CharField(max_length=255, null=True)
-
-
-class AbonnementService(MyBaseModel):
-    client = models.ForeignKey(Client, on_delete=models.CASCADE)
-    prix_services = models.ManyToManyField(PrixService)
-    nb_seances = models.IntegerField()
-    is_active = models.BooleanField(default=True)
-    reduction = models.BigIntegerField(null=True)
 
 
 class AbonnementGym(MyBaseModel):

--- a/salon/forms.py
+++ b/salon/forms.py
@@ -40,14 +40,14 @@ class PrixServiceForm(forms.ModelForm):
 class PrestationForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
         # Supprimer les Labels par defaut
         for field_name in self.fields:
             self.fields[field_name].label = ''
 
     class Meta:
         model = Prestation
-        fields = ['service', 'montant_a_payer', 'montant_reduit', 'fait_par']
+        fields = ['service', 'prix_service', 'init_prestation']
 
 
 class ProduitForm(forms.ModelForm):

--- a/salon/views.py
+++ b/salon/views.py
@@ -10,9 +10,9 @@ from django.views.decorators.http import require_http_methods
 
 from client.models import Client
 from employe.models import Employe
-from salon.forms import ServiceForm, CategorieForm, PrixServiceForm, PrestationForm, ProduitForm, ApproProduitForm
-from salon.models import CategorieService, Service, PrixService, Prestation, Produit, Approvisionnement, Vente, \
-    ProduitVendu
+from salon.forms import ServiceForm, CategorieForm, PrixServiceForm, ProduitForm, ApproProduitForm, PrestationForm
+from salon.models import CategorieService, Service, PrixService, Produit, Approvisionnement, Vente, \
+    ProduitVendu, Prestation
 
 tmp = "salon/"
 


### PR DESCRIPTION
- Refonte de certains models des apps Client et Salon
    Explode du model Prestation en deux:
        Init Prestation et Prestation
   Explode du model Abonnement en 2:
       InitAbonnementService et DetailsAbonnementService;
       Et le deplacement de ces 2 modeles de l'app Client vers l'app Salon pour eviter le probleme de dépendance circulaire entre les deux applications.