### PR TITLE
Add username field, make eamil field nullable

### DIFF
--- a/employe/models.py
+++ b/employe/models.py
@@ -3,21 +3,25 @@ from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, Permis
 from django.db import models
 
 class EmployeManager(BaseUserManager):
-    def create_user(self, email, password=None, **extra_fields):
-        if not email:
-            raise ValueError("L'adresse e-mail est obligatoire.")
-        email = self.normalize_email(email)
+    def create_user(self, username, password=None, **extra_fields):
+        if not username:
+            raise ValueError("Le nom d'utilisateur est obligatoire")
+
         extra_fields.setdefault('is_active', True)
-        user = self.model(email=email, **extra_fields)
+        # Normaliser l'email s'il est fourni
+        if 'email' in extra_fields and extra_fields['email']:
+            extra_fields['email'] = self.normalize_email(extra_fields['email'])
+
+        user = self.model(username=username, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
         return user
 
-    def create_superuser(self, email, password=None, **extra_fields):
+    def create_superuser(self, username, password=None, **extra_fields):
         extra_fields.setdefault('is_staff', True)
         extra_fields.setdefault('is_superuser', True)
 
-        return self.create_user(email, password, **extra_fields)
+        return self.create_user(username, password, **extra_fields)
 
 class Employe(AbstractBaseUser, PermissionsMixin):
     id = models.UUIDField(
@@ -25,7 +29,8 @@ class Employe(AbstractBaseUser, PermissionsMixin):
         editable=False,
         default=uuid.uuid4
     )
-    email = models.EmailField(unique=True)
+    username = models.CharField(max_length=150, unique=True)
+    email = models.EmailField(null=True, blank=True, max_length=255)
     first_name = models.CharField(max_length=50)
     last_name = models.CharField(max_length=50)
     telephone = models.CharField(max_length=18)
@@ -34,11 +39,11 @@ class Employe(AbstractBaseUser, PermissionsMixin):
 
     objects = EmployeManager()
 
-    USERNAME_FIELD = 'email'  # Définit l'identifiant principal
+    USERNAME_FIELD = 'username'  # Définit l'identifiant principal
     REQUIRED_FIELDS = ['first_name', 'last_name']
 
     def __str__(self):
-        return self.email
+        return f'{self.first_name} {self.last_name} {self.telephone}'
 
 
 

--- a/employe/templates/employe/add_employe.html
+++ b/employe/templates/employe/add_employe.html
@@ -163,12 +163,12 @@
                 email: $('#id_email').val().trim(),
             };
 
-            if(!formData.first_name || !formData.last_name || !formData.telephone || !formData.email){
+            if(!formData.first_name || !formData.last_name || !formData.telephone){
                 $("#response-message").text("Tous les champs sont obligatoires.")
-                $('#response-message').addClass('show').fadeIn();
+                $('#response-message').removeClass("bg-success").addClass('show bg-warning').fadeIn();
                 setTimeout(function(){
-                    $("#response-message").removeClass('show').fadeOut();
-                }, 3000)
+                    $("#response-message").removeClass('bg-warning show').fadeOut();
+                }, 5000)
                 return
             }
 

--- a/employe/views.py
+++ b/employe/views.py
@@ -1,5 +1,6 @@
 import http
 import json
+import uuid
 from collections import defaultdict
 from datetime import date, timedelta
 
@@ -146,15 +147,21 @@ def add_employe(request):
         try:
             data = json.loads(request.body)
             #  Verification des champs cote serveur
-            required_fields = ['first_name', 'last_name', 'telephone', 'email']
+            required_fields = ['first_name', 'last_name', 'telephone']
             for field in required_fields:
                 if not escape(data.get(field)):
                     return JsonResponse({"error": f"{field} est obligatoire"}, status=400)
 
             # Enregistrement de l'employe
+            # Recuperer le prenom de l'employe et le mettre tout en minuscule sans espace
+            base_first_name = data['first_name'].lower().replace(" ", "")
+
+            # Ajouter 8 caracteres uniques d'un uuid au prenom pour former le username par default
+            unique_part = str(uuid.uuid4())[:8]
+            username = f"{base_first_name}_{unique_part}"
             employee = Employe.objects.create_user(
                 first_name=data['first_name'], last_name=data['last_name'],
-                email=data['email'], telephone=data['telephone']
+                email=data['email'], telephone=data['telephone'], username=username,
             )
 
 

--- a/salon/models.py
+++ b/salon/models.py
@@ -43,7 +43,7 @@ class Prestation(MyBaseModel):
     service = models.ForeignKey(Service, on_delete=models.SET_NULL, null=True)
     prix_service = models.BigIntegerField()
     init_prestation = models.ForeignKey(InitPrestation, on_delete=models.CASCADE)
-    fait_par = models.ManyToManyField("employe.Employe", null=True, related_name="prestations_realisees")
+    fait_par = models.ManyToManyField("employe.Employe", related_name="prestations_realisees")
 
     def __str__(self):
         return f"{self.service.designation} - {self.fait_par.first_name} {self.fait_par.last_name} - InitPrest: {self.init_prestation}"


### PR DESCRIPTION
### Changer le mode d'authentification

L'authentification se faisait via adresse email et mot de passe

Ramener a la methode par defaut de django en utilisant username et password puis rendre l'email nullable (optionnel)

A la creation d'un employe un pseudo username est créé en utilisant le prenom de l'utilisateur en minuscule et sans espace suivit d'un UUID